### PR TITLE
Add RabbitMQ library

### DIFF
--- a/.env
+++ b/.env
@@ -60,3 +60,7 @@ EMAIL_PASS="****"
 GOOGLE_CLIENT_ID=***
 GOOGLE_CLIENT_SECRET=***
 GOOGLE_REDIRECT_URI=http://localhost:3000/api/v1/login/google/callback
+
+# RabbitMQ
+RABBITMQ_URL=amqp://localhost:5672
+RABBITMQ_QUEUE=nestjs

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.3.3",
     "@nestjs/event-emitter": "^2.0.4",
+    "@nestjs/microservices": "^10.3.3",
     "@nestjs/platform-express": "^10.3.3",
     "@nestjs/swagger": "^7.3.0",
     "@nestjs/typeorm": "^10.0.2",

--- a/src/infra/secrets/adapter.ts
+++ b/src/infra/secrets/adapter.ts
@@ -34,6 +34,11 @@ export abstract class ISecretsAdapter {
 
   REDIS_URL: string;
 
+  RABBITMQ: {
+    URL?: string;
+    QUEUE?: string;
+  };
+
   ZIPKIN_URL: string;
 
   PROMETHUES_URL: string;

--- a/src/infra/secrets/module.ts
+++ b/src/infra/secrets/module.ts
@@ -41,6 +41,10 @@ import { EnvEnum } from './types';
           PORT: z.number(),
           PROMETHUES_URL: z.string().url(),
           REDIS_URL: z.string().url(),
+          RABBITMQ: z.object({
+            URL: z.string().url(),
+            QUEUE: z.string()
+          }),
           TOKEN_EXPIRATION: z.string(),
           ZIPKIN_URL: z.string().url(),
           EMAIL: z.object({

--- a/src/infra/secrets/service.ts
+++ b/src/infra/secrets/service.ts
@@ -28,6 +28,11 @@ export class SecretsService implements ISecretsAdapter {
 
   REDIS_URL = this.config.get('REDIS_URL');
 
+  RABBITMQ = {
+    URL: this.config.get('RABBITMQ_URL'),
+    QUEUE: this.config.get('RABBITMQ_QUEUE')
+  };
+
   MONGO = {
     MONGO_URL: this.config.get('MONGO_URL'),
     MONGO_DATABASE: this.config.get('MONGO_DATABASE'),

--- a/src/libs/module.ts
+++ b/src/libs/module.ts
@@ -3,9 +3,16 @@ import { Module } from '@nestjs/common';
 import { CryptoLibModule } from './crypto';
 import { EventLibModule } from './event';
 import { I18nLibModule } from './i18n';
+import { RabbitMQLibModule } from './rabbitmq';
 import { TokenLibModule } from './token';
 
 @Module({
-  imports: [TokenLibModule, CryptoLibModule, EventLibModule, I18nLibModule]
+  imports: [
+    TokenLibModule,
+    CryptoLibModule,
+    EventLibModule,
+    I18nLibModule,
+    RabbitMQLibModule
+  ]
 })
 export class LibModule {}

--- a/src/libs/rabbitmq/adapter.ts
+++ b/src/libs/rabbitmq/adapter.ts
@@ -1,0 +1,4 @@
+export abstract class IRabbitMQAdapter {
+  abstract publish<T>(routingKey: string, payload: T): Promise<void>;
+  abstract subscribe<T>(routingKey: string, handler: (data: T) => void): Promise<void>;
+}

--- a/src/libs/rabbitmq/index.ts
+++ b/src/libs/rabbitmq/index.ts
@@ -1,0 +1,3 @@
+export * from './adapter';
+export * from './module';
+export * from './service';

--- a/src/libs/rabbitmq/module.ts
+++ b/src/libs/rabbitmq/module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+
+import { ISecretsAdapter, SecretsModule } from '@/infra/secrets';
+
+import { IRabbitMQAdapter } from './adapter';
+import { RabbitMQService } from './service';
+
+@Module({
+  imports: [SecretsModule],
+  providers: [
+    {
+      provide: IRabbitMQAdapter,
+      useFactory: (secret: ISecretsAdapter) => new RabbitMQService(secret),
+      inject: [ISecretsAdapter]
+    }
+  ],
+  exports: [IRabbitMQAdapter]
+})
+export class RabbitMQLibModule {}

--- a/src/libs/rabbitmq/service.ts
+++ b/src/libs/rabbitmq/service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { ClientProxy, ClientProxyFactory, Transport } from '@nestjs/microservices';
+import { firstValueFrom } from 'rxjs';
+
+import { ISecretsAdapter } from '@/infra/secrets';
+
+import { IRabbitMQAdapter } from './adapter';
+
+export type PublishOutput = void;
+export type SubscribeOutput = void;
+
+@Injectable()
+export class RabbitMQService implements IRabbitMQAdapter {
+  private client: ClientProxy;
+
+  constructor(private readonly secret: ISecretsAdapter) {
+    this.client = ClientProxyFactory.create({
+      transport: Transport.RMQ,
+      options: {
+        urls: [this.secret.RABBITMQ.URL],
+        queue: this.secret.RABBITMQ.QUEUE,
+        queueOptions: { durable: true }
+      }
+    });
+  }
+
+  async publish<T>(routingKey: string, payload: T): Promise<PublishOutput> {
+    await firstValueFrom(this.client.emit(routingKey, payload));
+  }
+
+  async subscribe<T>(routingKey: string, handler: (data: T) => void): Promise<SubscribeOutput> {
+    await this.client.connect();
+    this.client.send<T, void>(routingKey, undefined).subscribe(handler);
+  }
+}


### PR DESCRIPTION
## Summary
- add RabbitMQ lib wrapping `@nestjs/microservices`
- register RabbitMQ in LibModule
- expose RabbitMQ connection config in Secrets service
- document RabbitMQ env vars
- include `@nestjs/microservices` dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f2e7f44c832aaa473f5751c27ffd