### PR TITLE
Configure GitLab CI with Docker support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+image: node:22
+
+services:
+  - docker:dind
+
+variables:
+  DOCKER_TLS_CERTDIR: ""
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_DRIVER: overlay2
+  NODE_ENV: test
+
+stages:
+  - test
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - .pnpm-store
+
+before_script:
+  - apt-get update && apt-get install -y docker.io docker-compose
+  - corepack enable
+  - pnpm install --frozen-lockfile
+
+test:
+  stage: test
+  before_script:
+    - docker-compose -f docker-compose-infra.yml up -d
+  script:
+    - pnpm test
+  after_script:
+    - docker-compose -f docker-compose-infra.yml down -v


### PR DESCRIPTION
## Summary
- add `.gitlab-ci.yml` to enable GitLab CI
  - use Docker-in-Docker service for Testcontainers
  - run infra with `docker-compose` before tests

## Testing
- `pnpm test` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68707bba029c832a9fa816e0e9126322